### PR TITLE
Implemented Delete Domain API

### DIFF
--- a/src/main/java/com/psipher/application/actions/UserDetailsOperations.java
+++ b/src/main/java/com/psipher/application/actions/UserDetailsOperations.java
@@ -48,4 +48,12 @@ public interface UserDetailsOperations {
      */
     UserDDBModel viewDetails(String userId) throws DDBException;
 
+    /**
+     * This will delete domain for the specified userId
+     * @param userId userId psipher specific
+     * @param domain domain like google.com etc
+     * @return status
+     * @throws DDBException dynamoDB custom exception
+     */
+    String deleteDomain(String userId, String domain) throws DDBException;
 }

--- a/src/main/java/com/psipher/application/actions/UserDetailsOperationsImpl.java
+++ b/src/main/java/com/psipher/application/actions/UserDetailsOperationsImpl.java
@@ -90,6 +90,27 @@ public class UserDetailsOperationsImpl implements UserDetailsOperations {
         dynamoDBMapper.save(userDDBModel);
     }
 
+    @Override
+    public String deleteDomain(String userId, String domain) throws DDBException {
+        UserDDBModel userDDBModel = viewDetails(userId);
+        List<WebsiteDDBModel> websiteDDBModels = userDDBModel.getWebsites();
+        for (WebsiteDDBModel websiteDDBModel : websiteDDBModels) {
+            if (websiteDDBModel.getDomain().equals(domain)) {
+                websiteDDBModels.remove(websiteDDBModel);
+                break;
+            }
+        }
+        String status;
+        try {
+            dynamoDBMapper.save(userDDBModel);
+            status = "success";
+        } catch (Exception e) {
+            logger.error(String.format("Failed to delete domain: %s for userId: %s exception: %s", domain, userId, e.getMessage()));
+            throw new DDBException("Failed to delete domain");
+        }
+        return status;
+    }
+
     /**
      * Search for the account if already exists then update it else create a new one
      * @param userAccountDDBModels list of account present in the domain

--- a/src/main/java/com/psipher/application/api/DeleteDomain.java
+++ b/src/main/java/com/psipher/application/api/DeleteDomain.java
@@ -1,0 +1,47 @@
+package com.psipher.application.api;
+
+import com.psipher.application.actions.UserDetailsOperations;
+import com.psipher.application.exceptions.DDBException;
+import com.psipher.application.model.DeleteDomainInput;
+import com.psipher.application.model.DeleteDomainOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DeleteDomain {
+    UserDetailsOperations userDetailsOperations;
+
+    private static final Logger logger = LoggerFactory.getLogger(DeleteDomain.class);
+
+    final static String INVALID_INPUT = "Invalid input";
+
+    @Autowired
+    public DeleteDomain(UserDetailsOperations userDetailsOperations) {
+        this.userDetailsOperations = userDetailsOperations;
+    }
+
+    @RequestMapping(path = "/deletedomain", method = RequestMethod.POST)
+    public DeleteDomainOutput deleteDomain(@RequestBody DeleteDomainInput deleteDomainInput) {
+        if (!checkValidInput(deleteDomainInput))
+            return new DeleteDomainOutput(INVALID_INPUT);
+        String status;
+        try {
+            status = userDetailsOperations.deleteDomain(deleteDomainInput.getUserId(), deleteDomainInput.getDomain());
+        } catch (DDBException e) {
+            status = "Failure";
+            logger.error(e.getMessage());
+        }
+        return new DeleteDomainOutput(status);
+    }
+
+    private boolean checkValidInput(DeleteDomainInput deleteDomainInput) {
+        return deleteDomainInput != null && deleteDomainInput.getUserId() != null
+                && deleteDomainInput.getDomain() != null;
+    }
+
+}

--- a/src/main/java/com/psipher/application/api/DeleteDomain.java
+++ b/src/main/java/com/psipher/application/api/DeleteDomain.java
@@ -19,10 +19,6 @@ public class DeleteDomain {
     private static final Logger logger = LoggerFactory.getLogger(DeleteDomain.class);
 
     final static String INVALID_INPUT = "Invalid input";
-<<<<<<< HEAD
-=======
-    final static String UNKNOWN_USER = "Unknown User";
->>>>>>> 28384223f3150c7b693855399189046e082f095a
 
     @Autowired
     public DeleteDomain(UserDetailsOperations userDetailsOperations) {
@@ -32,11 +28,7 @@ public class DeleteDomain {
     @RequestMapping(path = "/deletedomain", method = RequestMethod.POST)
     public DeleteDomainOutput deleteDomain(@RequestBody DeleteDomainInput deleteDomainInput) {
         if (!checkValidInput(deleteDomainInput))
-<<<<<<< HEAD
             return new DeleteDomainOutput(INVALID_INPUT);
-=======
-            return new DeleteDomainOutput(deleteDomainInput != null ? deleteDomainInput.getUserId() : UNKNOWN_USER, INVALID_INPUT);
->>>>>>> 28384223f3150c7b693855399189046e082f095a
         String status;
         try {
             status = userDetailsOperations.deleteDomain(deleteDomainInput.getUserId(), deleteDomainInput.getDomain());
@@ -44,11 +36,7 @@ public class DeleteDomain {
             status = "Failure";
             logger.error(e.getMessage());
         }
-<<<<<<< HEAD
         return new DeleteDomainOutput(status);
-=======
-        return new DeleteDomainOutput(deleteDomainInput.getUserId(), status);
->>>>>>> 28384223f3150c7b693855399189046e082f095a
     }
 
     private boolean checkValidInput(DeleteDomainInput deleteDomainInput) {

--- a/src/main/java/com/psipher/application/model/DeleteDomainInput.java
+++ b/src/main/java/com/psipher/application/model/DeleteDomainInput.java
@@ -1,0 +1,13 @@
+package com.psipher.application.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteDomainInput {
+    private String userId;
+    private String domain;
+}

--- a/src/main/java/com/psipher/application/model/DeleteDomainOutput.java
+++ b/src/main/java/com/psipher/application/model/DeleteDomainOutput.java
@@ -1,0 +1,12 @@
+package com.psipher.application.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteDomainOutput {
+    private String status;
+}

--- a/src/main/java/com/psipher/application/model/DeleteDomainOutput.java
+++ b/src/main/java/com/psipher/application/model/DeleteDomainOutput.java
@@ -8,9 +8,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class DeleteDomainOutput {
-<<<<<<< HEAD
-=======
-    private String userId;
->>>>>>> 28384223f3150c7b693855399189046e082f095a
     private String status;
 }


### PR DESCRIPTION
### Implementations
**New Files**
- _/api/DeleteDomain_
    * Created deletedomain API to allow users to delete the selected domain-related userAccounts.
    * Receives the data from DeleteDomainInput i.e. userId and domain and passes to /actions/UserDetailOperationsImpl
    * Returns DeleteDomainOutput as response.
    * Handled all errors and exceptions
- _/model/DeleteDomainInput_
    *  Model to send userId and domain to DeleteDomain API. 
- _/model/DeleteDomainOutput_
    * Model for sending status as response

**Functions**
* _/actions/UserDetailOperationsImpl - deleteDomain()_
    * Created deleteDomain function to fetch domain corresponding to userId and remove them.

**Other**
* Added logs in all above functions

**Testing**
* Did testing using postman by sending a request and receiving a response.