### PR TITLE
New DeleteUserAccount API

### DIFF
--- a/src/main/java/com/psipher/application/actions/UserDetailsOperations.java
+++ b/src/main/java/com/psipher/application/actions/UserDetailsOperations.java
@@ -64,4 +64,14 @@ public interface UserDetailsOperations {
      * @throws DDBException dynamoDB custom exception
      */
     String deleteUser(String userId) throws DDBException;
+
+    /**
+     * This will delete userAccount in a particular domain of a user
+     * @param userId      userId psipher specific
+     * @param domain      domain like google.com etc
+     * @param userAccount account of the user in the domain
+     * @return status
+     * @throws DDBException dynamoDB custom exception
+     */
+    String deleteUserAccount(String userId, String domain, String userAccount) throws DDBException;
 }

--- a/src/main/java/com/psipher/application/actions/UserDetailsOperationsImpl.java
+++ b/src/main/java/com/psipher/application/actions/UserDetailsOperationsImpl.java
@@ -125,6 +125,43 @@ public class UserDetailsOperationsImpl implements UserDetailsOperations {
         return status;
     }
 
+    @Override
+    public String deleteUserAccount(String userId, String domain, String userAccount) throws DDBException {
+        UserDDBModel userDDBModel = viewDetails(userId);
+        List<WebsiteDDBModel> websiteDDBModels = userDDBModel.getWebsites();
+        for (WebsiteDDBModel websiteDDBModel : websiteDDBModels) {
+            if (websiteDDBModel.getDomain().equals(domain)) {
+                searchAccountAndDelete(websiteDDBModel.getUserAccountsDDBModel(), userAccount);
+                break;
+            }
+        }
+        String status;
+        try {
+            dynamoDBMapper.save(userDDBModel);
+            status = "success";
+        } catch (Exception e) {
+            logger.error(String.format("Failed to delete user account: %s in domain: %s for userId: %s exception: %s",
+                    userAccount, domain, userId, e.getMessage()));
+            throw new DDBException("Failed to delete userAccount");
+        }
+        return status;
+    }
+
+    /**
+     * Search for the account and deletes the record
+     *
+     * @param userAccountDDBModels list of account present in the domain
+     * @param userAccount          user account which is going to be deleted
+     */
+    private void searchAccountAndDelete(List<UserAccountDDBModel> userAccountDDBModels, String userAccount) {
+        for (UserAccountDDBModel userAccountDDBModel : userAccountDDBModels) {
+            if (userAccountDDBModel.getId().equals((userAccount))) {
+                userAccountDDBModels.remove(userAccountDDBModel);
+                break;
+            }
+        }
+    }
+
     /**
      * Search for the account if already exists then update it else create a new one
      * @param userAccountDDBModels list of account present in the domain

--- a/src/main/java/com/psipher/application/actions/UserDetailsOperationsImpl.java
+++ b/src/main/java/com/psipher/application/actions/UserDetailsOperationsImpl.java
@@ -155,7 +155,7 @@ public class UserDetailsOperationsImpl implements UserDetailsOperations {
      */
     private void searchAccountAndDelete(List<UserAccountDDBModel> userAccountDDBModels, String userAccount) {
         for (UserAccountDDBModel userAccountDDBModel : userAccountDDBModels) {
-            if (userAccountDDBModel.getId().equals((userAccount))) {
+            if (userAccountDDBModel.getId().equals(userAccount)) {
                 userAccountDDBModels.remove(userAccountDDBModel);
                 break;
             }

--- a/src/main/java/com/psipher/application/api/DeleteUserAccount.java
+++ b/src/main/java/com/psipher/application/api/DeleteUserAccount.java
@@ -1,0 +1,46 @@
+package com.psipher.application.api;
+
+import com.psipher.application.actions.UserDetailsOperations;
+import com.psipher.application.exceptions.DDBException;
+import com.psipher.application.model.DeleteUserAccountInput;
+import com.psipher.application.model.DeleteUserAccountOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DeleteUserAccount {
+    UserDetailsOperations userDetailsOperations;
+
+    private static final Logger logger = LoggerFactory.getLogger(DeleteUserAccount.class);
+
+    final static String INVALID_INPUT = "Invalid input";
+
+    @Autowired
+    public DeleteUserAccount(UserDetailsOperations userDetailsOperations) {
+        this.userDetailsOperations = userDetailsOperations;
+    }
+
+    @RequestMapping(path = "/deleteuseraccount", method = RequestMethod.POST)
+    public DeleteUserAccountOutput deleteUserAccount(@RequestBody DeleteUserAccountInput deleteUserAccountInput) {
+        if (!checkValidInput(deleteUserAccountInput))
+            return new DeleteUserAccountOutput(INVALID_INPUT);
+        String status;
+        try {
+            status = userDetailsOperations.deleteUserAccount(deleteUserAccountInput.getUserId(), deleteUserAccountInput.getDomain(), deleteUserAccountInput.getUserAccount());
+        } catch (DDBException e) {
+            status = "Failure";
+            logger.error(e.getMessage());
+        }
+        return new DeleteUserAccountOutput(status);
+    }
+
+    private boolean checkValidInput(DeleteUserAccountInput deleteUserAccountInput) {
+        return deleteUserAccountInput != null && deleteUserAccountInput.getUserId() != null
+                && deleteUserAccountInput.getDomain() != null && deleteUserAccountInput.getUserAccount() != null;
+    }
+}

--- a/src/main/java/com/psipher/application/model/DeleteUserAccountInput.java
+++ b/src/main/java/com/psipher/application/model/DeleteUserAccountInput.java
@@ -1,0 +1,14 @@
+package com.psipher.application.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteUserAccountInput {
+    private String userId;
+    private String domain;
+    private String userAccount;
+}

--- a/src/main/java/com/psipher/application/model/DeleteUserAccountOutput.java
+++ b/src/main/java/com/psipher/application/model/DeleteUserAccountOutput.java
@@ -1,0 +1,12 @@
+package com.psipher.application.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteUserAccountOutput {
+    private String status;
+}


### PR DESCRIPTION
### Implementations
**New Files**
- _/api/DeleteUserAccount_
    * Created DeleteUserAccount API to allow users to delete his user account from a domain.
    * Receives the data from DeleteUserAccountInput i.e. userId,domain,userAccount passes to /actions/UserDetailOperationsImpl
    * Returns DeleteUserAccountOutput as response.
    * Handled all errors and exceptions
- _/model/DeleteUserAccountInput_
    *  Model to send userId, domain and userAccount to DeleteUserId API. 
- _/model/DeleteUserAccountOutput_
    * Model for sending status as response

**Functions**
* _/actions/UserDetailOperationsImpl - deleteUserAccount()_
    * Created deleteUserAccount function to fetch userId, domain, userAccount and remove them.
* _/actions/UserDetailOperationsImpl -  searchAccountAndDelete()_
    * Created to search account and remove them.

**Other**
* Added logs in all above functions

**Testing**
* Did testing using postman by sending a request and receiving a response.